### PR TITLE
Added TargetPlatform

### DIFF
--- a/lib/src/build_context_impl.dart
+++ b/lib/src/build_context_impl.dart
@@ -74,6 +74,20 @@ extension ThemeExt on BuildContext {
   Color get scaffoldBackgroundColor => Theme.of(this).scaffoldBackgroundColor;
 
   AppBarTheme get appBarTheme => Theme.of(this).appBarTheme;
+  
+  TargetPlatform get platform => Theme.of(this).platform;
+
+  bool get isAndroid => this.platform == TargetPlatform.android;
+
+  bool get isIOS => this.platform == TargetPlatform.iOS;
+
+  bool get isMacOS => this.platform == TargetPlatform.macOS;
+
+  bool get isWindows => this.platform == TargetPlatform.windows;
+
+  bool get isFuchsia => this.platform == TargetPlatform.fuchsia;
+
+  bool get isLinux => this.platform == TargetPlatform.linux;
 }
 
 extension ScaffoldExt on BuildContext {


### PR DESCRIPTION
Sometimes you need to show different widgets for the platforms. To achieve this, you can use `Theme.of(context).platform == TargetPlatform.isAndroid`. But this is a little bit long. So I added this methods:

`context.platform` => `TragetPlatform`
`context.isAndroid` => `bool`
`context.isIOS` => `bool`
`context.isWindows` => `bool`
`context.isMacOS` => `bool`
`context.isLinux` => `bool`
`context.isFuchsia` => `bool`

Short questions: `context.isIOS` or `context.isIOs`? `context.isMacOS` or `context.isMacOs`?
