### PR TITLE
Added closeKeyboard()

### DIFF
--- a/lib/src/build_context_impl.dart
+++ b/lib/src/build_context_impl.dart
@@ -152,4 +152,6 @@ class _FocusScope {
 
 extension FocusScopeExt on BuildContext {
   _FocusScope get focusScope => _FocusScope(this);
+
+  void closeKeyboard() => this.focusScope.requestFocus(FocusNode());
 }


### PR DESCRIPTION
## Problem
To close the keyboard you have to call `context.focusScope.requestFocus(FocusNode())`. Its' not only a lot of code, but it's also hard to read, because you have to know, that `requestFocus(FocusNode())` will close the keyboard.

## Solution
A better solution is `context.closeKeyboard()`. It's very short and easy to read 👍
