### PR TITLE
Add TextStyle extension

### DIFF
--- a/README-pt-BR.md
+++ b/README-pt-BR.md
@@ -61,6 +61,20 @@ abaixo você pode ver as extensões que estão atualmente disponíveis na últim
 - `context.isLinux`
 - `context.isFuchsia`
 
+- `context.headline1`
+- `context.headline2`
+- `context.headline3`
+- `context.headline4`
+- `context.headline5`
+- `context.headline6`
+- `context.subtitle1`
+- `context.bodyText1`
+- `context.bodyText2`
+- `context.caption`
+- `context.button`
+- `context.subtitle2`
+- `context.overline`
+
 ### Da classe `Scaffold`. Lide com o seu Scaffold no seu `context`.
 Observação: Esses devem ser chamados no contexto de um widget `Scaffold`, caso contrário, você pode ter erros.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ bellow you can see the currently available extensions in the latest version.
 * `context.isLinux`
 * `context.isFuchsia`
 
+* `context.headline1`
+* `context.headline2`
+* `context.headline3`
+* `context.headline4`
+* `context.headline5`
+* `context.headline6`
+* `context.subtitle1`
+* `context.bodyText1`
+* `context.bodyText2`
+* `context.caption`
+* `context.button`
+* `context.subtitle2`
+* `context.overline`
+
 #### From `Scaffold` class. Handle your scaffold in their `context`. 
 Note: those must be called in the context of a `Scaffold` widget otherwise you might have errors.
 

--- a/lib/src/build_context_impl.dart
+++ b/lib/src/build_context_impl.dart
@@ -88,6 +88,32 @@ extension ThemeExt on BuildContext {
   bool get isFuchsia => this.platform == TargetPlatform.fuchsia;
 
   bool get isLinux => this.platform == TargetPlatform.linux;
+
+  TextStyle get headline1 => textTheme.headline1;
+
+  TextStyle get headline2 => textTheme.headline2;
+
+  TextStyle get headline3 => textTheme.headline3;
+
+  TextStyle get headline4 => textTheme.headline4;
+
+  TextStyle get headline5 => textTheme.headline5;
+
+  TextStyle get headline6 => textTheme.headline6;
+
+  TextStyle get subtitle1 => textTheme.subtitle1;
+
+  TextStyle get bodyText1 => textTheme.bodyText1;
+
+  TextStyle get bodyText2 => textTheme.bodyText2;
+
+  TextStyle get caption => textTheme.caption;
+
+  TextStyle get button => textTheme.button;
+
+  TextStyle get subtitle2 => textTheme.subtitle2;
+
+  TextStyle get overline => textTheme.overline;
 }
 
 extension ScaffoldExt on BuildContext {


### PR DESCRIPTION
Added TextStyle extension - #14 

Example:
`context.headline1`

Updated the doc with the new extension.