### PR TITLE
Migration to ScaffoldMessenger

### DIFF
--- a/lib/src/build_context_impl.dart
+++ b/lib/src/build_context_impl.dart
@@ -93,15 +93,15 @@ extension ThemeExt on BuildContext {
 extension ScaffoldExt on BuildContext {
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showSnackBar(
           SnackBar snackbar) =>
-      Scaffold.of(this).showSnackBar(snackbar);
+      ScaffoldMessenger.of(this).showSnackBar(snackbar);
 
   void removeCurrentSnackBar(
           {SnackBarClosedReason reason = SnackBarClosedReason.remove}) =>
-      Scaffold.of(this).removeCurrentSnackBar(reason: reason);
+      ScaffoldMessenger.of(this).removeCurrentSnackBar(reason: reason);
 
   void hideCurrentSnackBar(
           {SnackBarClosedReason reason = SnackBarClosedReason.hide}) =>
-      Scaffold.of(this).hideCurrentSnackBar(reason: reason);
+      ScaffoldMessenger.of(this).hideCurrentSnackBar(reason: reason);
 
   void openDrawer() => Scaffold.of(this).openDrawer();
 


### PR DESCRIPTION
Snackbar methods for `Scaffold.of(context)` are deprecated. We should use [ScaffoldMessenger](https://flutter.dev/docs/release/breaking-changes/scaffold-messenger).