### PR TITLE
Removal of deprecated getters

### DIFF
--- a/lib/src/build_context_impl.dart
+++ b/lib/src/build_context_impl.dart
@@ -60,8 +60,6 @@ extension ThemeExt on BuildContext {
 
   TextTheme get primaryTextTheme => Theme.of(this).primaryTextTheme;
 
-  TextTheme get accentTextTheme => Theme.of(this).accentTextTheme;
-
   BottomAppBarTheme get bottomAppBarTheme => Theme.of(this).bottomAppBarTheme;
 
   BottomSheetThemeData get bottomSheetTheme => Theme.of(this).bottomSheetTheme;
@@ -69,8 +67,6 @@ extension ThemeExt on BuildContext {
   Color get backgroundColor => Theme.of(this).backgroundColor;
 
   Color get primaryColor => Theme.of(this).primaryColor;
-
-  Color get buttonColor => Theme.of(this).buttonColor;
 
   Color get scaffoldBackgroundColor => Theme.of(this).scaffoldBackgroundColor;
 


### PR DESCRIPTION
This pull request addresses an issue in the latest version of Flutter, where the buttonColor and accentTextTheme getters have been deprecated, causing build failures. To resolve these issues, this pull request removes both getters from the codebase.

**Changes Made:**

Removed the deprecated buttonColor getter
Removed the deprecated accentTextTheme getter

**Additional Notes:**
It's worth noting that the deprecation of these getters aligns with Flutter's latest recommendations and changes in the framework. Removing them ensures the codebase remains up to date and avoids any potential issues in future versions of Flutter.

https://docs.flutter.dev/release/breaking-changes/theme-data-accent-properties